### PR TITLE
Use encodeURIComponent() instead of escape()

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,17 +184,17 @@ permissions and limitations under the License.
 
     function object2hrefvirt(bucket, object) {
         if (AWS.config.region === "us-east-1") {
-            return document.location.protocol + '//' + bucket + '.s3.amazonaws.com/' + escape(object);
+            return document.location.protocol + '//' + bucket + '.s3.amazonaws.com/' + encodeURIComponent(object);
         } else {
-            return document.location.protocol + '//' + bucket + '.s3-' + AWS.config.region + '.amazonaws.com/' + escape(object);
+            return document.location.protocol + '//' + bucket + '.s3-' + AWS.config.region + '.amazonaws.com/' + encodeURIComponent(object);
         }
     }
 
     function object2hrefpath(bucket, object) {
         if (AWS.config.region === "us-east-1") {
-            return document.location.protocol + "//s3.amazonaws.com/" + bucket + "/" + escape(object);
+            return document.location.protocol + "//s3.amazonaws.com/" + bucket + "/" + encodeURIComponent(object);
         } else {
-            return document.location.protocol + "//s3-' + AWS.config.region + '.amazonaws.com/" + bucket + "/" + escape(object);
+            return document.location.protocol + "//s3-' + AWS.config.region + '.amazonaws.com/" + bucket + "/" + encodeURIComponent(object);
         }
     }
 


### PR DESCRIPTION
This solves a problem where URLs to objects that have "+" in the filename would throw a 404.

In our specific use case we have filenames with SemVer version info that includes build metadata e.g. product-1.0.0+1-1.zip

Also, the escape() function is deprecated so it's probably good to use encodeURIComponent() regardless: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features