### PR TITLE
Add files dialog

### DIFF
--- a/explorer.js
+++ b/explorer.js
@@ -295,6 +295,11 @@ app.controller('ViewController', function($scope, SharedService) {
         }
     };
 
+    $scope.upload = function() {
+        DEBUG.log('Add files');
+        $('#addedFiles').trigger('click');
+    };
+
     $scope.trash = function() {
         DEBUG.log('Trash:', $scope.view.keys_selected);
         if ($scope.view.keys_selected.length > 0) {
@@ -847,7 +852,7 @@ app.controller('UploadController', function($scope, SharedService) {
 
                 var droppedFiles = [];
                 var fileIndex = droppedFiles.length;
-                var files = e.originalEvent.dataTransfer.files;
+                var files = e.hasOwnProperty('originalEvent') ? e.originalEvent.dataTransfer.files : SharedService.added_files;
 
                 for (var ii = 0; ii < files.length; ii++) {
                     var fileii = files[ii];
@@ -900,6 +905,12 @@ app.controller('UploadController', function($scope, SharedService) {
                     $scope.upload.uploading = false;
                });
 
+                // Reset files selector
+                if (SharedService.hasOwnProperty('added_files')) {
+                    delete SharedService.added_files;
+                    $('#addedFiles').val('');
+                }
+
                 // Launch the uploader modal
                 $('#UploadModal').modal({ keyboard: true, backdrop: 'static' });
             });
@@ -907,6 +918,13 @@ app.controller('UploadController', function($scope, SharedService) {
 
     // Enable dropzone behavior and highlighting
     $scope.dropZone($('.dropzone'));
+
+    // Simulate drop event on change of files selector
+    $('#addedFiles').on('change', function(e) {
+        SharedService.added_files = e.target.files;
+        $('.dropzone').trigger('drop');
+    });
+
 });
 
 //

--- a/index.html
+++ b/index.html
@@ -419,11 +419,11 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
                                 </div>
                                 <!-- Record count -->
                                 <div class="btn-group" ng-hide="!view.settings || view.keys_selected.length > 0">
-                                    <span id="badgecount" class="btn badge pull-right" title="Object count">{{view.objectCount}}</span>
+                                    <span id="badgecount" style="cursor: default;" class="btn badge pull-right" title="Object count">{{view.objectCount}}</span>
                                 </div>
                                 <!-- Record/checked count -->
                                 <div class="btn-group" ng-hide="!view.settings || view.keys_selected.length == 0">
-                                    <span id="badgecount" class="btn badge pull-right" title="Selected object count">{{view.keys_selected.length}} of {{view.objectCount}}</span>
+                                    <span id="badgecount" style="cursor: default;" class="btn badge pull-right" title="Selected object count">{{view.keys_selected.length}} of {{view.objectCount}}</span>
                                 </div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ permissions and limitations under the License.
                     <fieldset>
                         <div class="modal-header">
                             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                            <h4 class="modal-title">S3 Explorer: Add Folder</h4>
+                            <h4 class="modal-title">S3 Explorer: New Folder</h4>
                         </div>
                         <div class="modal-body">
                             <div class="col-md-18">
@@ -411,7 +411,7 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
                             <div>
                                 <!-- Info/Refresh/Settings buttons -->
                                 <div class="btn-group">
-                                    <span id="bucket-plus" style="cursor: pointer;" class="btn fa fa-folder-plus fa-2x" title="Add folder" data-target="#AddFolderModal" data-toggle="modal"></span>
+                                    <span id="bucket-plus" style="cursor: pointer;" class="btn fa fa-folder-plus fa-2x" ng-hide="!view.settings" title="New folder" data-target="#AddFolderModal" data-toggle="modal"></span>
                                     <span id="bucket-trash" style="cursor: pointer;" class="btn fa fa-trash-alt fa-2x" title="Delete {{view.keys_selected.length}} selected object(s)" ng-hide="!view.settings || !view.keys_selected.length" ng-disabled="!view.keys_selected.length" ng-click="trash()"></span>
                                     <span id="bucket-info" style="cursor: pointer;" class="btn fa fa-info-circle fa-2x" title="Info" data-target="#InfoModal" data-toggle="modal"></span>
                                     <span id="bucket-loader" style="cursor: pointer;" class="btn fa fa-sync fa-2x" ng-hide="!view.settings" ng-click="refresh()" title="Refresh"></span>

--- a/index.html
+++ b/index.html
@@ -337,6 +337,9 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
         </div>
     </div>
 
+    <!-- Hidden selector for adding files -->
+    <input id="addedFiles" type="file" ng-hide="true" multiple/>
+
     <!-- Upload modal -->
     <div id="UploadModal" class="modal fade" ng-controller="UploadController" tabindex="-1">
         <div class="modal-dialog">
@@ -412,6 +415,7 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
                                 <!-- Info/Refresh/Settings buttons -->
                                 <div class="btn-group">
                                     <span id="bucket-plus" style="cursor: pointer;" class="btn fa fa-folder-plus fa-2x" ng-hide="!view.settings" title="New folder" data-target="#AddFolderModal" data-toggle="modal"></span>
+                                    <span id="bucket-upload" style="cursor: pointer;" class="btn fa fa-cloud-upload-alt fa-2x" ng-hide="!view.settings" ng-click="upload()" title="Upload files"></span>
                                     <span id="bucket-trash" style="cursor: pointer;" class="btn fa fa-trash-alt fa-2x" title="Delete {{view.keys_selected.length}} selected object(s)" ng-hide="!view.settings || !view.keys_selected.length" ng-disabled="!view.keys_selected.length" ng-click="trash()"></span>
                                     <span id="bucket-info" style="cursor: pointer;" class="btn fa fa-info-circle fa-2x" title="Info" data-target="#InfoModal" data-toggle="modal"></span>
                                     <span id="bucket-loader" style="cursor: pointer;" class="btn fa fa-sync fa-2x" ng-hide="!view.settings" ng-click="refresh()" title="Refresh"></span>


### PR DESCRIPTION
This pull request is to add traditional file 'Browse and select' dialog in addition to existing drag and drop feature as the latter seems a bit confusing and might cause annoying entire page replacement in case of inaccurate drop.

The changes are in three commits:

1. 'Add folder' title has been changed to 'New folder' to avoid feeling that user can add entire files directory to S3 bucket, which is not possible
2. A cursor style has been changed to default for counter fileds as they are not meant to be clickable
3. Browser file selection dialog has been assigned to 'Upload files' button, next to 'Add folder' button