### PR TITLE
Feature/issue 44 config via url

### DIFF
--- a/explorer.js
+++ b/explorer.js
@@ -134,12 +134,15 @@ function SharedService($rootScope) {
         DEBUG.log('SharedService::changeSettings settings', settings);
 
         if ('URLSearchParams' in window) {
+            // store settings in query parameter
+            // create a deep copy and redact sensitive information
+            const settingsCopy = JSON.parse(JSON.stringify(settings));
+            settingsCopy.cred.secretAccessKey = "";
+            settingsCopy.cred.sessionToken = "";
+            settingsCopy.mfa.code = "";
+
             const searchParams = new URLSearchParams(window.location.search)
-            var secret = settings.cred.secretAccessKey;
-            settings.cred.secretAccessKey = "";
-            searchParams.set("settings", btoa(JSON.stringify(settings)));
-            settings.cred.secretAccessKey = secret;
-            secret = null;
+            searchParams.set("settings", btoa(JSON.stringify(settingsCopy)));
             const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
             history.replaceState(null, '', newRelativePathQuery);
         }

--- a/explorer.js
+++ b/explorer.js
@@ -135,7 +135,11 @@ function SharedService($rootScope) {
 
         if ('URLSearchParams' in window) {
             const searchParams = new URLSearchParams(window.location.search)
+            var secret = settings.cred.secretAccessKey;
+            settings.cred.secretAccessKey = "";
             searchParams.set("settings", btoa(JSON.stringify(settings)));
+            settings.cred.secretAccessKey = secret;
+            secret = null;
             const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
             history.replaceState(null, '', newRelativePathQuery);
         }

--- a/explorer.js
+++ b/explorer.js
@@ -102,6 +102,13 @@ function stripLeadTrailSlash(s) {
     return s.replace(/^\/+/g, '').replace(/\/+$/g, '');
 }
 
+// Get a url query string value for key
+function qs(key) {
+    key = key.replace(/[*+?^$.\[\]{}()|\\\/]/g, "\\$&"); // escape RegEx meta chars
+    var match = location.search.match(new RegExp("[?&]"+key+"=([^&]+)(&|$)"));
+    return match && decodeURIComponent(match[1].replace(/\+/g, " "));
+}
+
 //
 // Shared service that all controllers can use
 //
@@ -874,9 +881,22 @@ function SettingsController($scope, SharedService) {
 
     // Initialized for an unauthenticated user exploring the current bucket
     // TODO: calculate current bucket and initialize below
-    $scope.settings = {
+
+    const defaultSettings = {
         auth: 'anon', region: '', bucket: '', entered_bucket: '', selected_bucket: '', view: 'folder', delimiter: '/', prefix: '',
     };
+    $scope.settings = defaultSettings;
+
+    const encodedSettings = qs('settings');
+
+    if(encodedSettings){
+        const settingsJSON = atob(encodedSettings);
+        const settingsObj = JSON.parse(settingsJSON);
+        // merge loaded settings with defaults
+        // todo check whether ES6 features are allowed (spread operator)
+        $scope.settings = { ...$scope.settings, ...settingsObj };
+    }
+
     $scope.settings.mfa = { use: 'no', code: '' };
     $scope.settings.cred = { accessKeyId: '', secretAccessKey: '', sessionToken: '' };
     $scope.settings.stscred = null;

--- a/explorer.js
+++ b/explorer.js
@@ -133,6 +133,13 @@ function SharedService($rootScope) {
         DEBUG.log('SharedService::changeSettings');
         DEBUG.log('SharedService::changeSettings settings', settings);
 
+        if ('URLSearchParams' in window) {
+            const searchParams = new URLSearchParams(window.location.search)
+            searchParams.set("settings", btoa(JSON.stringify(settings)));
+            const newRelativePathQuery = window.location.pathname + '?' + searchParams.toString();
+            history.replaceState(null, '', newRelativePathQuery);
+        }
+
         this.settings = settings;
         this.viewprefix = null;
         $.fn.dataTableExt.afnFiltering.length = 0;
@@ -885,6 +892,11 @@ function SettingsController($scope, SharedService) {
     const defaultSettings = {
         auth: 'anon', region: '', bucket: '', entered_bucket: '', selected_bucket: '', view: 'folder', delimiter: '/', prefix: '',
     };
+
+    defaultSettings.mfa = { use: 'no', code: '' };
+    defaultSettings.cred = { accessKeyId: '', secretAccessKey: '', sessionToken: '' };
+    defaultSettings.stscred = null;
+
     $scope.settings = defaultSettings;
 
     const encodedSettings = qs('settings');
@@ -892,14 +904,8 @@ function SettingsController($scope, SharedService) {
     if(encodedSettings){
         const settingsJSON = atob(encodedSettings);
         const settingsObj = JSON.parse(settingsJSON);
-        // merge loaded settings with defaults
-        // todo check whether ES6 features are allowed (spread operator)
-        $scope.settings = { ...$scope.settings, ...settingsObj };
+        $scope.settings = settingsObj;
     }
-
-    $scope.settings.mfa = { use: 'no', code: '' };
-    $scope.settings.cred = { accessKeyId: '', secretAccessKey: '', sessionToken: '' };
-    $scope.settings.stscred = null;
 
     // TODO: at present the Settings dialog closes after credentials have been supplied
     // even if the subsequent AWS calls fail with networking or permissions errors. It


### PR DESCRIPTION
Issue: 44

Description of changes: Whenever settings change the url is updated with a base64 encoded version of the entire settings object. The url can be shared and bookmarked. When loading the settings controller, the url is checked for the `settings` query param and it is decoded when found. This pre-populates the settings modal

Areas for improvement
- instead of serializing the entire settings, only store the changes with respect to the defaults. This might help a bit with reducing the url length. But not sure whether long urls instead of very long urls make a meaningful difference
- a request was made for storing it in a more human-readable form instead of base64. Don't see the need myself, though
- users still are presented with the settings modal. In case no auth is required, it woiuld be nice if the modal could be skipped. My angular knowledge is not sufficient to get this working though.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
