### PR TITLE
Folders upload

### DIFF
--- a/explorer.css
+++ b/explorer.css
@@ -162,3 +162,10 @@ table.dataTable tbody tr {
     min-width: 25px;
     width: 0%;
 }
+
+@media (min-width: 768px) {
+  .modal-xl {
+    width: 90%;
+   max-width:1200px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
 
     <!-- Trash modal -->
     <div id="TrashModal" class="modal fade" ng-controller="TrashController" tabindex="-1">
-        <div class="modal-dialog modal-lg">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -389,7 +389,7 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
 
     <!-- Upload modal -->
     <div id="UploadModal" class="modal fade" ng-controller="UploadController" tabindex="-1">
-        <div class="modal-dialog">
+        <div class="modal-dialog modal-xl">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
@@ -414,7 +414,7 @@ Please see the project <a target="_blank" href="https://github.com/awslabs/aws-j
                                 <tbody id="upload-tbody">
                                     <tr ng-repeat="file in upload.files">
                                         <td>{{$index + 1}}</td>
-                                        <td>{{file.name}}</td>
+                                        <td>{{file.short}}</td>
                                         <td>{{file.type}}</td>
                                         <td>{{file.size}}</td>
                                         <td id="upload-td-{{$index}}">


### PR DESCRIPTION
*Issue #54*

*Description of changes:*

This is recursive folder uploading implementation (using drag and drop).
It includes Upload and Trash modals improvements to correctly show very long keys.

Limitations:
- only works in browsers, supporting [webkitGetAsEntry](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry)
- does not support empty folders: if dropped, they are skipped
- does not create zero-sized objects in folders, hence folders disappear if all their inner objects deleted

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
