### PR TITLE
Fix creating new folder when view prefix is specified

### DIFF
--- a/explorer.js
+++ b/explorer.js
@@ -792,6 +792,7 @@ function AddFolderController($scope, SharedService) {
         DEBUG.log('AddFolderController', 'broadcast change settings bucket:', args.settings.bucket);
         $scope.add_folder.settings = args.settings;
         $scope.add_folder.bucket = args.settings.bucket;
+		$scope.add_folder.view_prefix = args.settings.prefix || '/';
         DEBUG.log('AddFolderController add_folder bcs', $scope.add_folder);
     });
 

--- a/explorer.js
+++ b/explorer.js
@@ -792,7 +792,7 @@ function AddFolderController($scope, SharedService) {
         DEBUG.log('AddFolderController', 'broadcast change settings bucket:', args.settings.bucket);
         $scope.add_folder.settings = args.settings;
         $scope.add_folder.bucket = args.settings.bucket;
-		$scope.add_folder.view_prefix = args.settings.prefix || '/';
+        $scope.add_folder.view_prefix = args.settings.prefix || '/';
         DEBUG.log('AddFolderController add_folder bcs', $scope.add_folder);
     });
 


### PR DESCRIPTION
There is an issue if you choose to specify some path prefix at Settings view: 
1. Open JS S3 Explorer. Settings modal window will open. 
2. Set all the settings and enter some existing prefix path. Press "Query S3".
3. Explorer will open correct path. Press "Add new folder" icon. 
4. In this window for adding new folder as prefix you will see root ("/") path instead of current folder path (which equals to specified prefix path at settings window). And if you enter folder name here and press "Add folder" it will try to create it at root.

Note: This only happens if after opening explorer window you haven't changed current folder by using breadcrumb or any folder link.  

This commit fixes this bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
