### PR TITLE
Drag and drop improvement

### DIFF
--- a/explorer.js
+++ b/explorer.js
@@ -1089,15 +1089,17 @@ function UploadController($scope, SharedService) {
         }
         while (queue.length > 0) {
             const entry = queue.shift();
-            if (entry.isFile) {
-                // eslint-disable-next-line no-await-in-loop
-                const file = await filePromise(entry);
-                file.fullPath = entry.fullPath.substring(1);
-                fileEntries.push(file);
-            } else if (entry.isDirectory) {
-                const reader = entry.createReader();
-                // eslint-disable-next-line no-await-in-loop
-                queue.push(...await readAllDirectoryEntries(reader));
+            if (entry) {
+                if (entry.isFile) {
+                    // eslint-disable-next-line no-await-in-loop
+                    const file = await filePromise(entry);
+                    file.fullPath = entry.fullPath.substring(1);
+                    fileEntries.push(file);
+                } else if (entry.isDirectory) {
+                    const reader = entry.createReader();
+                    // eslint-disable-next-line no-await-in-loop
+                    queue.push(...await readAllDirectoryEntries(reader));
+                }
             }
         }
         return fileEntries;
@@ -1138,6 +1140,11 @@ function UploadController($scope, SharedService) {
                     ? SharedService.getAddedFiles()
                     : await getFilesList(e.originalEvent.dataTransfer);
                 $bl.removeClass('fa-spin');
+
+                if (!files.length) {
+                    DEBUG.log('Nothing to upload');
+                    return false;
+                }
 
                 $scope.$apply(() => {
                     $scope.upload.files = [];
@@ -1189,6 +1196,8 @@ function UploadController($scope, SharedService) {
 
                 // Launch the uploader modal
                 $('#UploadModal').modal({ keyboard: true, backdrop: 'static' });
+
+                return false;
             });
     };
 


### PR DESCRIPTION
*Issue:*

This has discovered by my partner tester. If one drags any draggable element from the application page itself (e.g. file/folder link or Previous/Next button) and drops it into the drop zone, the application goes broken (e.g. one can't enter a folder anymore).

Also if empty folder dropped into the drop zone, upload dialog with zero items appears (which could be considered as a minor bug).

*Description of changes:*

This change makes wrong stuff ignored if dropped into the drop zone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
