### PR TITLE
Let us cancel uploads properly

### DIFF
--- a/explorer.js
+++ b/explorer.js
@@ -967,12 +967,18 @@ function UploadController($scope, SharedService) {
     DEBUG.log('UploadController init');
     window.uploadScope = $scope; // for debugging
     $scope.upload = {
-        button: null, title: null, files: [],
+        button: null, title: null, files: [], uploads: [],
     };
 
     // Cache jquery selectors
     const $btnUpload = $('#upload-btn-upload');
     const $btnCancel = $('#upload-btn-cancel');
+
+    // Add new click handler for Cancel button
+    $btnCancel.click((e2) => {
+        e2.preventDefault();
+        $scope.upload.uploads.forEach(upl => upl.abort());
+    });
 
     //
     // Upload a list of local files to the provided bucket and prefix
@@ -1013,6 +1019,11 @@ function UploadController($scope, SharedService) {
                     // and we do not treat this as completely unexpected
                     if (err.code === 'AccessDenied') {
                         $(`#upload-td-${ii}`).html('<span class="uploaderror">Access Denied</span>');
+                    } else if (err.code === 'RequestAbortedError') {
+                        DEBUG.log(err.message);
+                        $btnUpload.hide();
+                        $btnCancel.text('Close');
+                        SharedService.viewRefresh();
                     } else {
                         DEBUG.log(JSON.stringify(err));
                         $(`#upload-td-${ii}`).html(`<span class="uploaderror">Failed:&nbsp${err.code}</span>`);
@@ -1037,9 +1048,11 @@ function UploadController($scope, SharedService) {
                 }
             };
 
-            s3.upload(params)
-                .on('httpUploadProgress', funcprogress)
-                .send(funcsend);
+            const upl = s3.upload(params);
+            $scope.$apply(() => {
+                $scope.upload.uploads.push(upl);
+            });
+            upl.on('httpUploadProgress', funcprogress).send(funcsend);
         });
     };
 

--- a/explorer.js
+++ b/explorer.js
@@ -985,6 +985,7 @@ function UploadController($scope, SharedService) {
     //
     $scope.uploadFiles = (Bucket, prefix) => {
         $scope.$apply(() => {
+            $scope.upload.uploads = [];
             $scope.upload.uploading = true;
         });
 


### PR DESCRIPTION
*Description of changes:*

I have discovered that Cancel button in Upload dialog doesn't do anything except the dialog hiding.
However, upload continues after that and files appear in the bucket corrupted.

With this pull request we will cancel uploads properly issuing `abort()` call for every managed upload created. No corrupted files will appear, while completed ones are kept intact.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
