### PR TITLE
Fixed #142 Migrate ESLint configuration from legacy .eslintrc to flat…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": ["eslint:recommended", "airbnb"],
-  "rules": {
-    "indent": ["error", 4]
-  }
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,50 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+    js.configs.recommended,
+    {
+        languageOptions: {
+            ecmaVersion: 2020,
+            sourceType: "script",
+            globals: {
+                ...globals.browser,
+                AWS: "readonly",
+                bootbox: "readonly",
+                moment: "readonly",
+                $: "readonly",
+                angular: "writable",
+            },
+        },
+        rules: {
+            // Carry over from .eslintrc
+            "indent": ["error", 4],
+
+            // Carry over from inline overrides in explorer.js
+            "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+            "no-console": "off",
+            "no-plusplus": "off",
+
+            // Airbnb-style rules that are reasonable to keep without
+            // pulling in the full airbnb config (which doesn't yet
+            // ship a flat config). Add or remove as desired.
+            "curly": ["error", "multi-line"],
+            "eqeqeq": ["error", "always", { "null": "ignore" }],
+            "no-var": "error",
+            "prefer-const": ["error", { "destructuring": "all" }],
+            "no-throw-literal": "error",
+            "no-param-reassign": ["error", { "props": false }],
+            "no-shadow": "error",
+            "no-use-before-define": ["error", { "functions": false, "classes": true, "variables": true }],
+            "no-multi-spaces": "error",
+            "no-trailing-spaces": "error",
+            "semi": ["error", "always"],
+            "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+            "comma-dangle": ["error", "always-multiline"],
+            "space-before-blocks": "error",
+            "keyword-spacing": "error",
+            "arrow-spacing": "error",
+            "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0 }],
+        },
+    },
+];

--- a/explorer.js
+++ b/explorer.js
@@ -12,13 +12,6 @@
 // either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-/* ESLint file-level overrides */
-/* global AWS bootbox document moment window $ angular:true */
-/* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
-/* eslint-disable no-console */
-/* eslint no-plusplus: "off" */
-/* eslint-env es6 */
-
 const s3ExplorerColumns = {
     check: 0, object: 1, folder: 2, date: 3, timestamp: 4, storageclass: 5, size: 6,
 };
@@ -848,7 +841,6 @@ function AddFolderController($scope, SharedService) {
 // Note: do not be tempted to correct the eslint no-unused-vars error
 // with SharedService below. Doing so will break injection.
 //
-// eslint-disable-next-line no-shadow
 function InfoController($scope) {
     DEBUG.log('InfoController init');
     window.infoScope = $scope; // for debugging
@@ -1100,7 +1092,6 @@ function UploadController($scope, SharedService) {
         let readEntries = await readEntriesPromise(directoryReader);
         while (readEntries.length > 0) {
             entries.push(...readEntries);
-            // eslint-disable-next-line no-await-in-loop
             readEntries = await readEntriesPromise(directoryReader);
         }
         return entries;
@@ -1130,13 +1121,11 @@ function UploadController($scope, SharedService) {
             const entry = queue.shift();
             if (entry) {
                 if (entry.isFile) {
-                    // eslint-disable-next-line no-await-in-loop
                     const file = await filePromise(entry);
                     file.fullPath = entry.fullPath.substring(1);
                     fileEntries.push(file);
                 } else if (entry.isDirectory) {
                     const reader = entry.createReader();
-                    // eslint-disable-next-line no-await-in-loop
                     queue.push(...await readAllDirectoryEntries(reader));
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "aws-js-s3-explorer",
+  "version": "1.0.0",
+  "description": "AWS JavaScript S3 Explorer",
+  "main": "explorer.js",
+  "scripts": {
+    "lint": "eslint explorer.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@eslint/js": "^9.39.3",
+    "eslint": "^9.39.3",
+    "globals": "^17.4.0"
+  }
+}


### PR DESCRIPTION
Fix #142 Migrate ESLint configuration from legacy `.eslintrc` to flat config (`eslint.config.mjs`)

ESLint v9+ dropped support for the legacy `.eslintrc` configuration format in favor of the new [flat config](https://eslint.org/docs/latest/use/configure/migration-guide) format. Our repo still uses `.eslintrc`, which means:

- ESLint v9+ refuses to run against our codebase
- We're pinned to ESLint v8 (end-of-life) for linting
- The `eslint-config-airbnb` dependency has no flat config support, so we need to either shim it or replace it

*Description of changes:*

- Create `eslint.config.mjs` with equivalent rules (`eslint:recommended` + curated Airbnb-style rules)
- Add `package.json` with `eslint`, `@eslint/js`, and `globals` as dev dependencies
- Remove legacy `.eslintrc`
- Remove now-redundant inline ESLint directives from `explorer.js` (`/* global */`, `/* eslint-env */`, `/* eslint-disable */`, etc.)
- Clean up stale `eslint-disable-next-line` comments for rules that no longer trigger

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
