### PR TITLE
Update #142 to suppress eslint parsing error for MJS

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import globals from "globals";
 export default [
     js.configs.recommended,
     {
+        files: ["**/*.js"],
         languageOptions: {
             ecmaVersion: 2020,
             sourceType: "script",
@@ -45,6 +46,12 @@ export default [
             "keyword-spacing": "error",
             "arrow-spacing": "error",
             "no-multiple-empty-lines": ["error", { "max": 1, "maxEOF": 0 }],
+        },
+    },
+    {
+        files: ["**/*.mjs"],
+        languageOptions: {
+            sourceType: "module",
         },
     },
 ];


### PR DESCRIPTION
ESLint flat config applies `sourceType: "script"` to `.mjs` files.

After the ESLint migration in #142, the flat config in `eslint.config.mjs` sets `sourceType: "script"` globally. This causes editors with ESLint integration to report a parsing error on `eslint.config.mjs` itself:

> Parsing error: 'import' and 'export' may appear only with 'sourceType: module'

Description of changes:
- Scope the `sourceType: "script"` setting to `**/*.js` files only
- Add a separate config block for `**/*.mjs` files with `sourceType: "module"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
